### PR TITLE
Feature/issue 5 static login seal routes => master

### DIFF
--- a/src/components/pages/login/interfaces.ts
+++ b/src/components/pages/login/interfaces.ts
@@ -1,0 +1,16 @@
+export enum EFormStateFieldsKeys {
+  Login = "login",
+  Password = "password",
+}
+
+export type IFormState = {
+  [key in EFormStateFieldsKeys]: string;
+};
+
+export type TErrorCode = "toShort" | "empty" | "wrongEntry" | null;
+
+export interface IFormValidation {
+  validate: boolean;
+  [EFormStateFieldsKeys.Login]: TErrorCode;
+  [EFormStateFieldsKeys.Password]: TErrorCode;
+}

--- a/src/components/pages/login/login.tsx
+++ b/src/components/pages/login/login.tsx
@@ -1,55 +1,146 @@
-import React from "react";
+import React, { ChangeEvent, useState } from "react";
 import { RouteComponentProps } from "react-router-dom";
 import { useTranslation } from "react-i18next";
 import Grid from "@material-ui/core/Grid";
 
+import { baseLogin, basePassword } from "staticLogin";
 import { staticRoutes } from "logics/router";
+
 import {
   loginMessagesKeys as keys,
   ENamesSpaces,
 } from "resources/translation/keys";
 
+import {
+  EFormStateFieldsKeys,
+  IFormState,
+  IFormValidation,
+  TErrorCode,
+} from "./interfaces";
 import { Paper, TextField, GridItem, LoginButton } from "./styled";
 
 interface ILoginProps extends RouteComponentProps {}
 
+const initialFormState: IFormState = {
+  login: "",
+  password: "",
+};
+
+const initialFormValidation: IFormValidation = {
+  validate: false,
+  login: "empty",
+  password: "empty",
+};
+
 export const Login = (props: ILoginProps) => {
   const { t: translation } = useTranslation(ENamesSpaces.LoginMessage);
+  const [form, setForm] = useState<IFormState>(initialFormState);
+  const [formValidation, setFormValidation] = useState<IFormValidation>(
+    initialFormValidation,
+  );
 
-  const isValid = true;
+  const handleSubmit = () => {
+    const loginIsValid = form.login === baseLogin;
+    const passwordIsValid = form.password === basePassword;
 
-  const loginHelperTextMessage = isValid
-    ? "*" + translation(keys.info_messages.field_required)
-    : translation(keys.alerts.unknown_login);
+    if (loginIsValid && passwordIsValid) {
+      props.history.push(staticRoutes.list);
+      return;
+    }
 
-  const passwordHelperTextMessage = isValid
-    ? "*" + translation(keys.info_messages.field_required)
-    : translation(keys.alerts.unknown_login);
+    let loginError: TErrorCode = formValidation.login;
+    let passwordError: TErrorCode = formValidation.password;
 
-  const onLoginSubmit = () => {
-    props.history.push(staticRoutes.list);
+    if (!loginIsValid && !formValidation.login) {
+      loginError = "wrongEntry";
+    }
+
+    if (!passwordIsValid && !formValidation.password) {
+      passwordError = "wrongEntry";
+    }
+
+    setFormValidation({
+      login: loginError,
+      password: passwordError,
+      validate: true,
+    });
   };
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const targetName = event.target.name as EFormStateFieldsKeys;
+    const targetValue = event.target.value;
+    let errorCode = formValidation[targetName];
+
+    if (targetValue.length < 6) {
+      errorCode = "toShort";
+      if (targetValue.length === 0) {
+        errorCode = "empty";
+      }
+    } else {
+      errorCode = null;
+    }
+
+    setForm({ ...form, [targetName]: targetValue });
+    setFormValidation({ ...formValidation, [targetName]: errorCode });
+  };
+
+  const getHelperText = (type: EFormStateFieldsKeys) => {
+    if (!formValidation.validate) {
+      return translation(keys.info_messages.field_required);
+    }
+
+    const wrongEntry: IFormState = {
+      login: "unknown_login",
+      password: "wrong_password",
+    };
+
+    switch (formValidation[type]) {
+      case "empty":
+        return translation(keys.alerts.empty_field);
+
+      case "toShort":
+        return translation(keys.alerts.minimum_charts);
+
+      case "wrongEntry":
+        return translation(
+          keys.alerts[wrongEntry[type] as "unknown_login" | "wrong_password"],
+        );
+
+      default:
+        return "";
+    }
+  };
+
+  const loginHelperText = getHelperText(EFormStateFieldsKeys.Login);
+  const passwordHelperText = getHelperText(EFormStateFieldsKeys.Password);
 
   return (
     <Paper>
       <Grid container>
         <GridItem>
           <TextField
-            error={!isValid}
+            name={EFormStateFieldsKeys.Login}
+            error={formValidation.validate}
+            helperText={loginHelperText}
             label={translation(keys.labels.login)}
-            helperText={loginHelperTextMessage}
+            onChange={handleChange}
+            value={form.login}
           />
         </GridItem>
         <GridItem>
           <TextField
-            error={!isValid}
-            label={translation(keys.labels.password)}
-            helperText={passwordHelperTextMessage}
             $lastOfType
+            name={EFormStateFieldsKeys.Password}
+            error={formValidation.validate}
+            helperText={passwordHelperText}
+            label={translation(keys.labels.password)}
+            onChange={handleChange}
+            type={"password"}
+            value={form.password}
           />
         </GridItem>
         <GridItem>
-          <LoginButton onClick={onLoginSubmit}>
+          <LoginButton onClick={handleSubmit}>
             {translation(keys.login_button)}
           </LoginButton>
         </GridItem>

--- a/src/components/pages/login/styled/text-field.tsx
+++ b/src/components/pages/login/styled/text-field.tsx
@@ -12,7 +12,7 @@ interface ICustomTextFieldProps extends StandardTextFieldProps {
 export const TextField = styled(TextFieldBase).attrs<ICustomTextFieldProps>(
   (props) => ({
     variant: props.variant || "outlined",
-    defaultValue: props?.defaultValue || " ",
+    type: props.type || "text",
   }),
 )<ICustomTextFieldProps>`
   && {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -3,7 +3,7 @@ import { initReactI18next } from "react-i18next";
 import { en, pl } from "./resources/translation/";
 
 i18n.use(initReactI18next).init({
-  lng: "en",
+  lng: "pl",
   debug: false,
   resources: {
     en: { ...en },

--- a/src/resources/translation/en/login.ts
+++ b/src/resources/translation/en/login.ts
@@ -3,14 +3,14 @@ import { ILoginMessages } from "../keys/";
 export const loginMessages: ILoginMessages = {
   alerts: {
     empty_field: "Field need to be filled",
-    minimum_four_charts:
-      "{validationValue} need to contains at least 4 characters",
+    minimum_charts:
+      "Field need to contains at least 6 characters",
     unknown_login: "Unknown login",
     wrong_password: "Wrong password",
   },
   info_messages: {
     field_required: "Field is required",
-    login_successful: "Login successful",
+    login_successful: "*Login successful",
   },
   labels: {
     login: "Login",

--- a/src/resources/translation/keys/loginMessages/interface.ts
+++ b/src/resources/translation/keys/loginMessages/interface.ts
@@ -1,7 +1,7 @@
 export interface ILoginMessages {
   alerts: {
     empty_field: string;
-    minimum_four_charts: string;
+    minimum_charts: string;
     unknown_login: string;
     wrong_password: string;
   };

--- a/src/resources/translation/keys/loginMessages/loginMessagesKeys.ts
+++ b/src/resources/translation/keys/loginMessages/loginMessagesKeys.ts
@@ -3,7 +3,7 @@ import { ILoginMessages } from "./interface";
 export const loginMessagesKeys: ILoginMessages = {
   alerts: {
     empty_field: "alerts.empty_field",
-    minimum_four_charts: "alerts.minimum_four_charts",
+    minimum_charts: "alerts.minimum_charts",
     unknown_login: "alerts.unknown_login",
     wrong_password: "alerts.wrong_password",
   },

--- a/src/resources/translation/pl/login.ts
+++ b/src/resources/translation/pl/login.ts
@@ -3,12 +3,12 @@ import { ILoginMessages } from "../keys/";
 export const loginMessages: ILoginMessages = {
   alerts: {
     empty_field: "Pole nie może być puste",
-    minimum_four_charts: "{validationValue} musi zawierać minimum 4 znaki",
+    minimum_charts: "Pole musi zawierać minimum 6 znaków",
     unknown_login: "Nieznany login",
     wrong_password: "Nieprawidłowe hasło",
   },
   info_messages: {
-    field_required: "Pole jest wymagane",
+    field_required: "*Pole jest wymagane",
     login_successful: "Logowanie pomyślne",
   },
   labels: {

--- a/src/staticLogin.ts
+++ b/src/staticLogin.ts
@@ -1,0 +1,2 @@
+export const baseLogin = "superuser";
+export const basePassword = "password";


### PR DESCRIPTION
@Kratak

* Change: [ISSUE-5] missing translation, default lang === pl
    
* Change: [ISSUE-5] Default props for text-field

+ Add: [ISSUE-5] static login and password
    
+ Add [ISSUE-5] Static Login and validations …
- Custom errors message, depend on condition
- translation match function
- full field sensitive validation
